### PR TITLE
fix(util): trim space for generating checksum address

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -127,7 +127,7 @@ func ToCheckSumAddress(address string) string {
 		}
 	}
 
-	return sb.String()
+	return strings.TrimSpace(sb.String())
 }
 
 func IntToHex(value, size int) string {


### PR DESCRIPTION
This pr is to avoid invisible character in some OS, like cloud9 which would bring a very hard time to debug for developers.