### PR TITLE
Fix/keystore

### DIFF
--- a/crypto/keystore.go
+++ b/crypto/keystore.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/Zilliqa/gozilliqa-sdk/keytools"
 	util2 "github.com/Zilliqa/gozilliqa-sdk/util"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 // 0: p 1:s
@@ -180,15 +180,11 @@ func (ks *Keystore) EncryptPrivateKey(privateKey, passphrase []byte, t KDFType) 
 		MAC:          util2.EncodeHex(mac),
 	}
 
-	uid, err := uuid.NewV4()
-	if err != nil {
-		panic(err)
-	}
-	uidString := uid.String()
+	uid := uuid.New()
 	kv := KeystoreV3{
 		Address: address,
 		Crypto:  crypto,
-		ID:      uidString,
+		ID:      uid.String(),
 		Version: 3,
 	}
 

--- a/crypto/keystore.go
+++ b/crypto/keystore.go
@@ -22,10 +22,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"strings"
+
 	"github.com/Zilliqa/gozilliqa-sdk/keytools"
 	util2 "github.com/Zilliqa/gozilliqa-sdk/util"
 	uuid "github.com/satori/go.uuid"
-	"strings"
 )
 
 // 0: p 1:s
@@ -179,10 +180,15 @@ func (ks *Keystore) EncryptPrivateKey(privateKey, passphrase []byte, t KDFType) 
 		MAC:          util2.EncodeHex(mac),
 	}
 
+	uid, err := uuid.NewV4()
+	if err != nil {
+		panic(err)
+	}
+	uidString := uid.String()
 	kv := KeystoreV3{
 		Address: address,
 		Crypto:  crypto,
-		ID:      uuid.NewV4().String(),
+		ID:      uidString,
 		Version: 3,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
-	github.com/satori/go.uuid v1.2.0
+  github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/stretchr/testify v1.5.1
 	github.com/tyler-smith/go-bip39 v1.0.2
 	github.com/ybbus/jsonrpc v2.1.2+incompatible

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
-  github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/stretchr/testify v1.5.1
 	github.com/tyler-smith/go-bip39 v1.0.2
 	github.com/ybbus/jsonrpc v2.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -30,9 +30,6 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=


### PR DESCRIPTION
The following error was thrown in the Keystore
```
# github.com/Zilliqa/gozilliqa-sdk/crypto
../../Zilliqa/gozilliqa-sdk/crypto/keystore.go:185:22: multiple-value uuid.NewV4() in single-value context
```
Issue has similarly being raised here. https://github.com/satori/go.uuid/issues/106. Looks like the function now returns multiple values, which broke the implementation. I've just made a hack and it works. 

# To decide

Should we stop using this dependency (https://github.com/satori/go.uuid) since it was last maintained in 2018? I saw that you are using "github.com/google/uuid" under the `workpool` package. I looked through briefly and I think it can replace this repository since it also follows the RFC 4122 standard.

The original repo is dead, and someone tried to create a fork https://github.com/gofrs/uuid which is also dead. 

Thoughts, @renlulu?

### System

go version 1.14.2
