### PR TITLE
fix(chainwalker): improve the polling for workpool

### DIFF
--- a/subscription/chainwalker_test.go
+++ b/subscription/chainwalker_test.go
@@ -26,8 +26,8 @@ func TestWalker_TraversalBlock(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip("Skipping testing in CI environment")
 	}
-	provider := provider2.NewProvider("https://dev-api.zilliqa.com/")
-	walker := NewWalker(provider, 933750, 933770, "0xab14b0fd133721d7c47ef410908e8ffc2b39167f", 50, "Transfer")
+	provider := provider2.NewProvider("https://api.zilliqa.com/")
+	walker := NewWalker(provider, 613524, 613525, "0x367093f076490df47b9d7ec3400d8104649175d6", 50, "Burnt")
 	walker.StartTraversalBlock()
 	t.Log(walker.EventLogs)
 }

--- a/workpool/workpool_test.go
+++ b/workpool/workpool_test.go
@@ -49,17 +49,19 @@ func TestNewWorkPool(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip("Skipping testing in CI environment")
 	}
-	quit := make(chan struct{})
+	quit := make(chan int, 1)
 	wp := NewWorkPool(10)
 	for i := 0; i < 10; i++ {
 		task := NewFakeTask()
 		wp.AddTask(task)
 	}
 
-	go func() {
-		wp.Poll(context.TODO(), quit)
-	}()
+	wp.Poll(context.TODO(), quit)
 
-	time.Sleep(time.Second * 10)
-	close(quit)
+	select {
+	case <-quit:
+		fmt.Println("done with test")
+		break
+	}
+
 }


### PR DESCRIPTION
This PR is to address the issue of handling tasks within workpool. Currently workpool will return immediately without waiting all tasks get completed, although user can wait outside (calling code) which is not so friendly.