### PR TITLE
Support batch sending payment transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ the section `quick start` first to get a basic understanding before you start to
 - [x] setDefault
 - [x] signTransaction (default account)
 - [x] signTransactionWith (specific account)
+- [x] SignBatch
+- [x] SendBatch (using JSON-RPC batch request or WaitGroup)
 
 ##### TransactionFactory Transaction
 
@@ -232,6 +234,50 @@ func TestSendTransaction(t *testing.T) {
 	fmt.Printf("hash is %s\n", hash)
 	tx.Confirm(hash, 1000, 3, provider)
 	assert.True(t, tx.Status == core.Confirmed)
+}
+```
+
+#### Send a batch of payment transactions
+
+```go
+func TestBatchSendTransaction(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+	wallet := NewWallet()
+	wallet.AddByPrivateKey("e19d05c5452598e24caad4a0d85a49146f7be089515c905ae6a19e8a578a6930")
+	provider := provider2.NewProvider("https://dev-api.zilliqa.com/")
+
+	gasPrice, err := provider.GetMinimumGasPrice()
+	assert.Nil(t, err, err)
+
+	var transactions []*transaction.Transaction
+	for i := 0; i < 100; i++ {
+		txn := &transaction.Transaction{
+			Version:      strconv.FormatInt(int64(util.Pack(333, 1)), 10),
+			SenderPubKey: "0246E7178DC8253201101E18FD6F6EB9972451D121FC57AA2A06DD5C111E58DC6A",
+			ToAddr:       "4BAF5faDA8e5Db92C3d3242618c5B47133AE003C",
+			Amount:       "10000000",
+			GasPrice:     gasPrice,
+			GasLimit:     "1",
+			Code:         "",
+			Data:         "",
+			Priority:     false,
+		}
+
+		transactions = append(transactions, txn)
+	}
+
+	err2 := wallet.SignBatch(transactions, *provider)
+	assert.Nil(t, err2, err2)
+
+	batchSendingResult,err := wallet.SendBatchOneGo(transactions, *provider)
+	if err != nil {
+		t.Fail()
+	} else {
+		fmt.Println(batchSendingResult)
+	}
 }
 ```
 

--- a/account/wallet_test.go
+++ b/account/wallet_test.go
@@ -83,6 +83,49 @@ func TestSendTransaction(t *testing.T) {
 	assert.True(t, tx.Status == core.Confirmed)
 }
 
+
+func TestBatchSendTransaction(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+	wallet := NewWallet()
+	wallet.AddByPrivateKey("e19d05c5452598e24caad4a0d85a49146f7be089515c905ae6a19e8a578a6930")
+	provider := provider2.NewProvider("https://dev-api.zilliqa.com/")
+
+	gasPrice, err := provider.GetMinimumGasPrice()
+	assert.Nil(t, err, err)
+
+	transactions := []*transaction.Transaction{
+		&transaction.Transaction{
+			Version:      strconv.FormatInt(int64(util.Pack(333, 1)), 10),
+			SenderPubKey: "0246E7178DC8253201101E18FD6F6EB9972451D121FC57AA2A06DD5C111E58DC6A",
+			ToAddr:       "4BAF5faDA8e5Db92C3d3242618c5B47133AE003C",
+			Amount:       "10000000",
+			GasPrice:     gasPrice,
+			GasLimit:     "1",
+			Code:         "",
+			Data:         "",
+			Priority:     false,
+		},
+	}
+
+	err2 := wallet.SignBatch(transactions, *provider)
+	assert.Nil(t, err2, err2)
+
+	tx := transactions[0]
+	fmt.Println(tx)
+	rsp, err3 := provider.CreateTransaction(tx.ToTransactionPayload())
+	assert.Nil(t, err3, err3)
+	assert.Nil(t, rsp.Error, rsp.Error)
+
+	resMap := rsp.Result.(map[string]interface{})
+	hash := resMap["TranID"].(string)
+	fmt.Printf("hash is %s\n", hash)
+	tx.Confirm(hash, 1000, 3, provider)
+	assert.True(t, tx.Status == core.Confirmed)
+}
+
+
 func TestSendTransactionInsufficientAmount(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip("Skipping testing in CI environment")

--- a/account/wallet_test.go
+++ b/account/wallet_test.go
@@ -97,7 +97,7 @@ func TestBatchSendTransaction(t *testing.T) {
 	assert.Nil(t, err, err)
 
 	var transactions []*transaction.Transaction
-	for i := 0; i < 15000; i++ {
+	for i := 0; i < 100; i++ {
 		txn := &transaction.Transaction{
 			Version:      strconv.FormatInt(int64(util.Pack(333, 1)), 10),
 			SenderPubKey: "0246E7178DC8253201101E18FD6F6EB9972451D121FC57AA2A06DD5C111E58DC6A",
@@ -116,9 +116,12 @@ func TestBatchSendTransaction(t *testing.T) {
 	err2 := wallet.SignBatch(transactions, *provider)
 	assert.Nil(t, err2, err2)
 
-	batchSendingResult := wallet.SendBatchAsync(transactions, *provider,200)
-	fmt.Println(batchSendingResult)
-
+	batchSendingResult,err := wallet.SendBatchOneGo(transactions, *provider)
+	if err != nil {
+		t.Fail()
+	} else {
+		fmt.Println(batchSendingResult)
+	}
 }
 
 func TestSendTransactionInsufficientAmount(t *testing.T) {

--- a/account/wallet_test.go
+++ b/account/wallet_test.go
@@ -96,7 +96,29 @@ func TestBatchSendTransaction(t *testing.T) {
 	assert.Nil(t, err, err)
 
 	transactions := []*transaction.Transaction{
-		&transaction.Transaction{
+		{
+			Version:      strconv.FormatInt(int64(util.Pack(333, 1)), 10),
+			SenderPubKey: "0246E7178DC8253201101E18FD6F6EB9972451D121FC57AA2A06DD5C111E58DC6A",
+			ToAddr:       "4BAF5faDA8e5Db92C3d3242618c5B47133AE003C",
+			Amount:       "10000000",
+			GasPrice:     gasPrice,
+			GasLimit:     "1",
+			Code:         "",
+			Data:         "",
+			Priority:     false,
+		},
+		{
+			Version:      strconv.FormatInt(int64(util.Pack(333, 1)), 10),
+			SenderPubKey: "0246E7178DC8253201101E18FD6F6EB9972451D121FC57AA2A06DD5C111E58DC6A",
+			ToAddr:       "4BAF5faDA8e5Db92C3d3242618c5B47133AE003C",
+			Amount:       "10000000",
+			GasPrice:     gasPrice,
+			GasLimit:     "1",
+			Code:         "",
+			Data:         "",
+			Priority:     false,
+		},
+		{
 			Version:      strconv.FormatInt(int64(util.Pack(333, 1)), 10),
 			SenderPubKey: "0246E7178DC8253201101E18FD6F6EB9972451D121FC57AA2A06DD5C111E58DC6A",
 			ToAddr:       "4BAF5faDA8e5Db92C3d3242618c5B47133AE003C",
@@ -112,17 +134,9 @@ func TestBatchSendTransaction(t *testing.T) {
 	err2 := wallet.SignBatch(transactions, *provider)
 	assert.Nil(t, err2, err2)
 
-	tx := transactions[0]
-	fmt.Println(tx)
-	rsp, err3 := provider.CreateTransaction(tx.ToTransactionPayload())
-	assert.Nil(t, err3, err3)
-	assert.Nil(t, rsp.Error, rsp.Error)
+	batchSendingResult := wallet.SendBatch(transactions,*provider)
+	fmt.Println(batchSendingResult)
 
-	resMap := rsp.Result.(map[string]interface{})
-	hash := resMap["TranID"].(string)
-	fmt.Printf("hash is %s\n", hash)
-	tx.Confirm(hash, 1000, 3, provider)
-	assert.True(t, tx.Status == core.Confirmed)
 }
 
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"github.com/Zilliqa/gozilliqa-sdk/core"
 	"github.com/ybbus/jsonrpc"
 	"io/ioutil"
@@ -495,10 +494,16 @@ func (provider *Provider) GetPendingTxns() (*jsonrpc.RPCResponse, error) {
 
 // Create a new Transaction object and send it to the network to be process.
 func (provider *Provider) CreateTransaction(payload TransactionPayload) (*jsonrpc.RPCResponse, error) {
-	r, _ := json.Marshal(payload)
-	fmt.Println(string(r))
-	//fmt.Println(payload)
 	return provider.call("CreateTransaction", &payload)
+}
+
+func (provider *Provider) CreateTransactionBatch(payloads [][]TransactionPayload) (jsonrpc.RPCResponses, error) {
+	var requests jsonrpc.RPCRequests
+	for _, payload := range payloads {
+		r := jsonrpc.NewRequest("CreateTransaction", payload)
+		requests = append(requests, r)
+	}
+	return provider.rpcClient.CallBatch(requests)
 }
 
 func (provider *Provider) CreateTransactionRaw(payload []byte) (*jsonrpc.RPCResponse, error) {


### PR DESCRIPTION
This PR is to support batch sending for payment transactions sequentially, by using JSON-RPC batch request or using golang WaitGroup. The typically use of this feature can be like:

```
func TestBatchSendTransaction(t *testing.T) {
	runtime.GOMAXPROCS(runtime.NumCPU())
	if os.Getenv("CI") != "" {
		t.Skip("Skipping testing in CI environment")
	}
	wallet := NewWallet()
	wallet.AddByPrivateKey("e19d05c5452598e24caad4a0d85a49146f7be089515c905ae6a19e8a578a6930")
	provider := provider2.NewProvider("https://dev-api.zilliqa.com/")

	gasPrice, err := provider.GetMinimumGasPrice()
	assert.Nil(t, err, err)

	var transactions []*transaction.Transaction
	for i := 0; i < 100; i++ {
		txn := &transaction.Transaction{
			Version:      strconv.FormatInt(int64(util.Pack(333, 1)), 10),
			SenderPubKey: "0246E7178DC8253201101E18FD6F6EB9972451D121FC57AA2A06DD5C111E58DC6A",
			ToAddr:       "4BAF5faDA8e5Db92C3d3242618c5B47133AE003C",
			Amount:       "10000000",
			GasPrice:     gasPrice,
			GasLimit:     "1",
			Code:         "",
			Data:         "",
			Priority:     false,
		}

		transactions = append(transactions, txn)
	}

	err2 := wallet.SignBatch(transactions, *provider)
	assert.Nil(t, err2, err2)

	batchSendingResult,err := wallet.SendBatchOneGo(transactions, *provider)
	if err != nil {
		t.Fail()
	} else {
		fmt.Println(batchSendingResult)
	}
}
```