### PR TITLE
feat(provider): support new getpendingtxns, format

### DIFF
--- a/account/wallet_test.go
+++ b/account/wallet_test.go
@@ -116,7 +116,7 @@ func TestBatchSendTransaction(t *testing.T) {
 	err2 := wallet.SignBatch(transactions, *provider)
 	assert.Nil(t, err2, err2)
 
-	batchSendingResult,err := wallet.SendBatchOneGo(transactions, *provider)
+	batchSendingResult, err := wallet.SendBatchOneGo(transactions, *provider)
 	if err != nil {
 		t.Fail()
 	} else {

--- a/core/types.go
+++ b/core/types.go
@@ -117,33 +117,33 @@ type Transaction struct {
 }
 
 type TransactionReceipt struct {
-	Accept bool `json:"accept"`
-	Errors interface{} `json:"errors"`
-	Exceptions []TransactionException `json:"exceptions"`
-	Success       bool          `json:"success"`
-	CumulativeGas string        `json:"cumulative_gas"`
-	EpochNum      string        `json:"epoch_num"`
-	EventLogs     []interface{} `json:"event_logs"`
-	Transitions []Transition `json:"transitions"`
+	Accept        bool                   `json:"accept"`
+	Errors        interface{}            `json:"errors"`
+	Exceptions    []TransactionException `json:"exceptions"`
+	Success       bool                   `json:"success"`
+	CumulativeGas string                 `json:"cumulative_gas"`
+	EpochNum      string                 `json:"epoch_num"`
+	EventLogs     []interface{}          `json:"event_logs"`
+	Transitions   []Transition           `json:"transitions"`
 }
 
 type TransactionException struct {
-	Line int `json:"line"`
+	Line    int    `json:"line"`
 	Message string `json:"message"`
 }
 
 type Transition struct {
-	Accept bool `json:"accept"`
-	Addr string `json:"addr"`
-	Depth int `json:"depth"`
-	Msg TransactionMessage `json:"msg"`
+	Accept bool               `json:"accept"`
+	Addr   string             `json:"addr"`
+	Depth  int                `json:"depth"`
+	Msg    TransactionMessage `json:"msg"`
 }
 
 type TransactionMessage struct {
-	Amount string `json:"_amount"`
-	Receipt string `json:"_receipt"`
-	Tag string `json:"_tag"`
-	Params []ContractValue `json:"params"`
+	Amount  string          `json:"_amount"`
+	Receipt string          `json:"_receipt"`
+	Tag     string          `json:"_tag"`
+	Params  []ContractValue `json:"params"`
 }
 
 type Transactions struct {
@@ -159,4 +159,45 @@ type ContractValue struct {
 type BalanceAndNonce struct {
 	Balance string `json:"balance"`
 	Nonce   int64  `json:"nonce"`
+}
+
+var PendingTxnError = map[int]string{
+	0:  "Txn was already processed and confirmed",
+	1:  "Pending - nonce too high",
+	2:  "Pending - blk gas limit exceeded",
+	3:  "Pending - consensus failure",
+	4:  "Error - txn not found",
+	10: "Dropped - math error",
+	11: "Dropped - scilla invocation error",
+	12: "Dropped - account init error",
+	13: "Dropped - invalid source account",
+	14: "Dropped - gas limit too high",
+	15: "Dropped - txn type unknown",
+	16: "Dropped - txn in wrong shard",
+	17: "Dropped - account in wrong shard",
+	18: "Dropped - code size too large",
+	19: "Dropped - txn verification error",
+	20: "Dropped - gas limit too low",
+	21: "Dropped - insuff balance",
+	22: "Dropped - insuff gas for checker",
+	23: "Dropped - duplicate txn found",
+	24: "Dropped - txn w/ higher gas found",
+	25: "Dropped - invalid dest account",
+	26: "Dropped - state addition error",
+}
+
+type PendingTxnResult struct {
+	Code      int  `json:"code"`
+	Confirmed bool `json:"confirmed"`
+	Info      string
+}
+
+type TransactionStatus struct {
+	Code    int    `json:"code"`
+	TxnHash string `json:"TxnHash"`
+	Info    string
+}
+
+type PendingTxns struct {
+	Txns []TransactionStatus
 }

--- a/core/types.go
+++ b/core/types.go
@@ -199,5 +199,5 @@ type TransactionStatus struct {
 }
 
 type PendingTxns struct {
-	Txns []TransactionStatus
+	Txns []*TransactionStatus
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -518,7 +518,7 @@ func (provider *Provider) GetPendingTxns() (*core.PendingTxns, error) {
 		return nil, err3
 	}
 
-	for _,tnx := range pendingTxns.Txns {
+	for _, tnx := range pendingTxns.Txns {
 		tnx.Info = core.PendingTxnError[tnx.Code]
 	}
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -468,28 +468,61 @@ func (provider *Provider) GetMinerInfo(dsNumber string) (*core.MinerInfo, error)
 	return &minerInfo, nil
 }
 
-// Returns the pending status of a specified Transaction. Possible results are:
-//
-//  confirmed	code	info
-//  false	0	Txn not pending
-//  false	1	Nonce too high
-//  false	2	Could not fit in as microblock gas limit reached
-//  false	3	Transaction valid but consensus not reached
-func (provider *Provider) GetPendingTxn(tx string) (*jsonrpc.RPCResponse, error) {
-	return provider.call("GetPendingTxn", tx)
+// Returns the pending status of a specified Transaction.
+func (provider *Provider) GetPendingTxn(tx string) (*core.PendingTxnResult, error) {
+	result, err := provider.call("GetPendingTxn", tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	var pendingResult core.PendingTxnResult
+	jsonString, err2 := json.Marshal(result.Result)
+	if err2 != nil {
+		return nil, err2
+	}
+
+	err3 := json.Unmarshal(jsonString, &pendingResult)
+	if err3 != nil {
+		return nil, err3
+	}
+
+	pendingResult.Info = core.PendingTxnError[pendingResult.Code]
+
+	return &pendingResult, nil
+
 }
 
 // Returns the pending status of all unvalidated Transactions.
-//
-//  For each entry, the possible results are:
-//
-//  confirmed	code	info
-//  false	0	Txn not pending
-//  false	1	Nonce too high
-//  false	2	Could not fit in as microblock gas limit reached
-//  false	3	Transaction valid but consensus not reached
-func (provider *Provider) GetPendingTxns() (*jsonrpc.RPCResponse, error) {
-	return provider.call("GetPendingTxns")
+func (provider *Provider) GetPendingTxns() (*core.PendingTxns, error) {
+	result, err := provider.call("GetPendingTxns")
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	var pendingTxns core.PendingTxns
+	jsonString, err2 := json.Marshal(result.Result)
+	if err2 != nil {
+		return nil, err2
+	}
+
+	err3 := json.Unmarshal(jsonString, &pendingTxns)
+	if err3 != nil {
+		return nil, err3
+	}
+
+	for _,tnx := range pendingTxns.Txns {
+		tnx.Info = core.PendingTxnError[tnx.Code]
+	}
+
+	return &pendingTxns, err
 }
 
 // Create a new Transaction object and send it to the network to be process.
@@ -544,18 +577,18 @@ func (provider *Provider) GetTransaction(transaction_hash string) (*core.Transac
 func (provider *Provider) GetTransactionBatch(transactionHashes []string) ([]*core.Transaction, error) {
 	var requests jsonrpc.RPCRequests
 	for _, hash := range transactionHashes {
-		r := jsonrpc.NewRequest("GetTransaction",[]string{hash})
-		requests = append(requests,r)
+		r := jsonrpc.NewRequest("GetTransaction", []string{hash})
+		requests = append(requests, r)
 	}
 
-	results,err := provider.rpcClient.CallBatch(requests)
+	results, err := provider.rpcClient.CallBatch(requests)
 	if err != nil {
 		return nil, err
 	}
 
 	var transactions []*core.Transaction
 
-	for _,result := range results {
+	for _, result := range results {
 		var transaction core.Transaction
 		jsonString, err2 := json.Marshal(result.Result)
 		if err2 != nil {
@@ -566,10 +599,10 @@ func (provider *Provider) GetTransactionBatch(transactionHashes []string) ([]*co
 			return transactions, err3
 		}
 
-		transactions = append(transactions,&transaction)
+		transactions = append(transactions, &transaction)
 	}
 
-	return transactions,nil
+	return transactions, nil
 
 }
 
@@ -797,7 +830,7 @@ func (provider *Provider) GetSmartContracts(user_address string) (*jsonrpc.RPCRe
 // Returns a smart contract address of 20 bytes. This is represented as a String.
 // NOTE: This only works for contract deployment transactions.
 func (provider *Provider) GetContractAddressFromTransactionID(transaction_id string) (string, error) {
-	result, err := provider.call("GetContractAddressFromTransactionID",transaction_id)
+	result, err := provider.call("GetContractAddressFromTransactionID", transaction_id)
 	if err != nil {
 		return "", err
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -174,6 +174,14 @@ func TestProvider_GetPendingTxn(t *testing.T) {
 	fmt.Println(string(result))
 }
 
+func TestProvider_GetPendingTxns(t *testing.T) {
+	SkipIfCI(t)
+	provider := NewProvider("https://dev-api.zilliqa.com/")
+	response, _ := provider.GetPendingTxns()
+	result, _ := json.Marshal(response)
+	fmt.Println(string(result))
+}
+
 func TestProvider_GetTotalCoinSupply(t *testing.T) {
 	SkipIfCI(t)
 	provider := NewProvider("https://dev-api.zilliqa.com/")
@@ -206,8 +214,8 @@ func TestGetTransaction(t *testing.T) {
 func TestProvider_GetTransactionBatch(t *testing.T) {
 	SkipIfCI(t)
 	provider := NewProvider("https://dev-api.zilliqa.com/")
-	transactions,_ := provider.GetTransactionBatch([]string{"c7d6550a6558edcddbf4b3c7cf14db9f1025200b89bcbcd6a570c84db58d554f","c7d6550a6558edcddbf4b3c7cf14db9f1025200b89bcbcd6a570c84db58d554f"})
-	st,_ := json.Marshal(transactions)
+	transactions, _ := provider.GetTransactionBatch([]string{"c7d6550a6558edcddbf4b3c7cf14db9f1025200b89bcbcd6a570c84db58d554f", "c7d6550a6558edcddbf4b3c7cf14db9f1025200b89bcbcd6a570c84db58d554f"})
+	st, _ := json.Marshal(transactions)
 	fmt.Println(string(st))
 }
 

--- a/subscription/chainwalker.go
+++ b/subscription/chainwalker.go
@@ -144,7 +144,7 @@ func (w *Walker) StartTraversalBlock() {
 			}
 
 			wp := workpool.NewWorkPool(w.WorkerNumber)
-			quit := make(chan int,1)
+			quit := make(chan int, 1)
 			for _, tx := range txns {
 				task := NewGetReceiptTask(tx, w.Provider, complete, w, i)
 				wp.AddTask(task)

--- a/workpool/workpool.go
+++ b/workpool/workpool.go
@@ -64,7 +64,7 @@ func (wp *WorkerPool) Top() Task {
 
 }
 
-func (wp * WorkerPool) Empty() bool {
+func (wp *WorkerPool) Empty() bool {
 	return len(wp.ids) == 0
 }
 


### PR DESCRIPTION
## Description
This PR is to support new getpendingtxns and getpendingtnx, and parse error code within sdk. 
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
Run following code (may need to send some pending transaction first):

```
func TestProvider_GetPendingTxn(t *testing.T) {
	provider := NewProvider("https://dev-api.zilliqa.com/")
	response, _ := provider.GetPendingTxn("2cf109b25f2132c08a4248e2be8add6b95b92aef5b2c77e737faefbc9353ee7c")
	result, _ := json.Marshal(response)
	fmt.Println(string(result))
}

func TestProvider_GetPendingTxns(t *testing.T) {
	provider := NewProvider("https://dev-api.zilliqa.com/")
	response, _ := provider.GetPendingTxns()
	result, _ := json.Marshal(response)
	fmt.Println(string(result))
}
```
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

