### PR TITLE
feat: compute transaction hash locally

### DIFF
--- a/account/wallet_test.go
+++ b/account/wallet_test.go
@@ -73,6 +73,9 @@ func TestSendTransaction(t *testing.T) {
 	err2 := wallet.Sign(tx, *provider)
 	assert.Nil(t, err2, err2)
 
+	h,_ := tx.Hash()
+	fmt.Println("local transaction hash: ",util.EncodeHex(h))
+
 	rsp, err3 := provider.CreateTransaction(tx.ToTransactionPayload())
 	assert.Nil(t, err3, err3)
 	assert.Nil(t, rsp.Error, rsp.Error)

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -129,6 +129,15 @@ func (t *Transaction) Bytes() ([]byte, error) {
 	}
 }
 
+func (t *Transaction) Hash() ([]byte,error){
+	bytes,err := t.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	hash := util.Sha256(bytes)
+	return hash,nil
+}
+
 func (t *Transaction) isPending() bool {
 	return t.Status == core.Pending
 }


### PR DESCRIPTION
## Description
This PR is to enable users to get transaction hash locally, without sending it to the network.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

