### PR TITLE
chore: move Hash function to package schnorr

### DIFF
--- a/schnorr/schnorr.go
+++ b/schnorr/schnorr.go
@@ -17,6 +17,7 @@
 package go_schnorr
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -58,7 +59,7 @@ func TrySign(privateKey []byte, publicKey []byte, message []byte, k []byte) ([]b
 
 	// 3. Compute the challenge r = H(Q || pubKey || msg)
 	// mod reduce r by the order of secp256k1, n
-	r := new(big.Int).SetBytes(util.Hash(Q, publicKey, message[:]))
+	r := new(big.Int).SetBytes(hash(Q, publicKey, message[:]))
 	r = r.Mod(r, keytools.Secp256k1.N)
 
 	if r.Cmp(bintZero) == 0 {
@@ -113,10 +114,18 @@ func Verify(publicKey []byte, msg []byte, r []byte, s []byte) bool {
 	Qx, Qy := keytools.Secp256k1.Add(rx, ry, lx, ly)
 	Q := util.Compress(keytools.Secp256k1, Qx, Qy, true)
 
-	_r := util.Hash(Q, publicKey, msg)
+	_r := hash(Q, publicKey, msg)
 
 	rn := new(big.Int).SetBytes(r)
 	_rn := new(big.Int).Mod(new(big.Int).SetBytes(_r),keytools.Secp256k1.N)
 	fmt.Printf("r = %s, _r = %s\n", hex.EncodeToString(r), hex.EncodeToString(_r))
 	return rn.Cmp(_rn) == 0
+}
+
+func hash(Q []byte, pubKey []byte, msg []byte) []byte {
+	var buffer bytes.Buffer
+	buffer.Write(Q)
+	buffer.Write(pubKey[:33])
+	buffer.Write(msg)
+	return util.Sha256(buffer.Bytes())
 }

--- a/util/util.go
+++ b/util/util.go
@@ -88,14 +88,6 @@ func bigIntToBytes(bi *big.Int) []byte {
 	return b1[:]
 }
 
-func Hash(Q []byte, pubKey []byte, msg []byte) []byte {
-	var buffer bytes.Buffer
-	buffer.Write(Q)
-	buffer.Write(pubKey[:33])
-	buffer.Write(msg)
-	return Sha256(buffer.Bytes())
-}
-
 func GenerateMac(derivedKey, cipherText, iv []byte) []byte {
 	buffer := bytes.NewBuffer(nil)
 	buffer.Write(derivedKey[16:32])


### PR DESCRIPTION
## Description
This PR is to move util.Hash to package schnorr, and make it private, that means it is only used by Sign function and should not be used publicly.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

