### PR TITLE
(fix) don't mutably multiply numbers when generating signatures

### DIFF
--- a/schnorr/schnorr.go
+++ b/schnorr/schnorr.go
@@ -67,8 +67,8 @@ func TrySign(privateKey []byte, publicKey []byte, message []byte, k []byte) ([]b
 
 	//4. Compute s = k - r * prv
 	// 4a. Compute r * prv
-	_r := *r
-	s := new(big.Int).Mod(_r.Mul(&_r, priKey), keytools.Secp256k1.N)
+	var v = new(big.Int).Mul(r, priKey)
+	s := new(big.Int).Mod(v, keytools.Secp256k1.N)
 	s = new(big.Int).Mod(new(big.Int).Sub(bintK, s), keytools.Secp256k1.N)
 
 	if s.Cmp(big.NewInt(0)) == 0 {


### PR DESCRIPTION
(fix) It is not generally safe to mutably multiply a bigint, though it does work if the number you are multiplying by is big enough (probably because either the result vector is reallocated or you just don't happen to write to a storage location before you've finished reading it).

Closes #120 

